### PR TITLE
Update Spring AI usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-openai-spring-boot-starter</artifactId>
-            <version>0.8.1</version>
+            <version>1.0.0-M6</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/com/example/events/config/OpenAiConfig.java
+++ b/src/main/java/com/example/events/config/OpenAiConfig.java
@@ -1,19 +1,14 @@
 package com.example.events.config;
 
-import org.springframework.ai.client.AiClient;
-import org.springframework.ai.openai.OpenAiChatClient;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OpenAiConfig {
 
-    @Value("${openai.api.key:}")
-    private String apiKey;
-
     @Bean
-    public AiClient aiClient() {
-        return new OpenAiChatClient(apiKey);
+    public ChatClient chatClient(ChatClient.Builder chatClientBuilder) {
+        return chatClientBuilder.build();
     }
 }

--- a/src/main/java/com/example/events/service/OpenAiService.java
+++ b/src/main/java/com/example/events/service/OpenAiService.java
@@ -1,20 +1,23 @@
 package com.example.events.service;
 
-import org.springframework.ai.client.AiClient;
+import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class OpenAiService {
 
-    private final AiClient aiClient;
+    private final ChatClient chatClient;
 
     @Autowired
-    public OpenAiService(AiClient aiClient) {
-        this.aiClient = aiClient;
+    public OpenAiService(ChatClient.Builder chatClientBuilder) {
+        this.chatClient = chatClientBuilder.build();
     }
 
     public String chat(String prompt) {
-        return aiClient.generate(prompt);
+        return this.chatClient.prompt()
+                .user(prompt)
+                .call()
+                .content();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,4 +5,4 @@ spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=update
 spring.h2.console.enabled=true
 
-openai.api.key=${OPENAI_API_KEY:}
+spring.ai.openai.api-key=${OPENAI_API_KEY:}


### PR DESCRIPTION
## Summary
- upgrade to `spring-ai-openai-spring-boot-starter` version 1.0.0-M6
- switch to `ChatClient` API in service and configuration
- update property key for OpenAI API

## Testing
- `mvn -q -DskipTests=true package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687685ecf5e483239b16a9a2d9ca5353