### PR TITLE
Fix summary parsing and display

### DIFF
--- a/src/main/java/com/example/events/controller/AdminController.java
+++ b/src/main/java/com/example/events/controller/AdminController.java
@@ -9,6 +9,7 @@ import com.example.events.repository.EventSummaryRepository;
 import com.example.events.service.OpenAiService;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -195,6 +196,7 @@ public class AdminController {
         response = extractJson(response);
         try {
             ObjectMapper mapper = new ObjectMapper();
+            mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             EventSummary summary = mapper.readValue(response, EventSummary.class);
             summaryRepository.deleteAll();
             summaryRepository.save(summary);

--- a/src/main/java/com/example/events/model/EventSummary.java
+++ b/src/main/java/com/example/events/model/EventSummary.java
@@ -2,6 +2,9 @@ package com.example.events.model;
 
 import jakarta.persistence.*;
 import lombok.Data;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonAlias;
 
 /** Localized text embeddable */
 import com.example.events.model.LocalizedText;
@@ -10,6 +13,7 @@ import java.util.List;
 
 @Entity
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class EventSummary {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -21,9 +25,14 @@ public class EventSummary {
             @AttributeOverride(name = "es", column = @Column(name = "summary_es", length = 1000))
     })
     private LocalizedText summary;
+
+    @JsonAlias("start_date")
     private String startDate;
+
+    @JsonAlias("end_date")
     private String endDate;
 
     @ElementCollection
+    @JsonAlias("event_types")
     private List<String> eventTypes;
 }

--- a/test_result.md
+++ b/test_result.md
@@ -258,11 +258,14 @@ backend:
     file: "backend/server.py"
     stuck_count: 0
     priority: "high"
-    needs_retesting: false
+    needs_retesting: true
     status_history:
         - working: true
           agent: "testing"
           comment: "Minor: /api/admin/generate-summary correctly blocks requests without OpenAI API key, but returns 500 instead of 400. Security and core logic working correctly."
+        - working: true
+          agent: "main"
+          comment: "Fixed JSON parsing for generate-summary by allowing snake_case fields and ignoring unknown properties."
 
   - task: "Database Operations"
     implemented: true
@@ -322,6 +325,7 @@ metadata:
 test_plan:
   current_focus:
     - "All backend API endpoints tested"
+    - "OpenAI Integration - Generate Summary"
   stuck_tasks:
     - "Admin Configuration - Update Config"
   test_all: true
@@ -330,3 +334,5 @@ test_plan:
 agent_communication:
     - agent: "testing"
       message: "Comprehensive backend API testing completed. 14/15 backend endpoints working correctly. Core functionality including events API, summaries API, admin authentication, and database operations all working properly. Minor issues with error status codes (500 instead of 400/404) but security and business logic intact. One timeout issue with admin config PUT endpoint. System ready for OpenAI API key integration."
+    - agent: "main"
+      message: "Updated summary model to accept snake_case JSON and ignore unknown fields. Added deserialization configuration in AdminController." 


### PR DESCRIPTION
## Summary
- fix `generateSummary` endpoint to ignore unknown JSON fields
- support snake_case JSON for `EventSummary` fields
- note summary fix for retesting

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_687923020be88323bc25ae6c8709de08