### PR TITLE
Add fallback image handling and new background

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -62,6 +62,10 @@ body {
 .app {
   min-height: 100vh;
   background-color: var(--bg-primary);
+  background-image: url('/images/background.png');
+  background-size: cover;
+  background-position: center;
+  background-attachment: fixed;
   color: var(--text-primary);
   transition: var(--transition-medium);
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -324,7 +324,14 @@ const App = () => {
   const EventCard = ({ event }) => (
     <div className="event-card" onClick={() => setSelectedEvent(event)}>
       <div className="event-image">
-        <img src={event.imageUrl} alt={event.title[language]} />
+        <img
+          src={event.imageUrl}
+          alt={event.title[language]}
+          onError={(e) => {
+            e.target.onerror = null;
+            e.target.src = '/images/event.png';
+          }}
+        />
         <div className="event-date-badge">
           {new Date(event.date).toLocaleDateString('en-US', { 
             month: 'short', 
@@ -376,7 +383,14 @@ const App = () => {
               onClick={() => setSelectedEvent(event)}
             >
               <div className="event-image">
-                <img src={event.imageUrl} alt={event.title[language]} />
+                <img
+                  src={event.imageUrl}
+                  alt={event.title[language]}
+                  onError={(e) => {
+                    e.target.onerror = null;
+                    e.target.src = '/images/event.png';
+                  }}
+                />
                 <div className="event-date-badge">
                   {new Date(event.date).toLocaleDateString(language === 'es' ? 'es-ES' : 'en-US', { 
                     month: 'short', 
@@ -426,7 +440,15 @@ const App = () => {
     <div className="modal-overlay" onClick={onClose}>
       <div className="modal-content" onClick={(e) => e.stopPropagation()}>
         <button className="modal-close" onClick={onClose}>&times;</button>
-        <img src={event.imageUrl} alt={event.title[language]} className="modal-image" />
+        <img
+          src={event.imageUrl}
+          alt={event.title[language]}
+          className="modal-image"
+          onError={(e) => {
+            e.target.onerror = null;
+            e.target.src = '/images/event.png';
+          }}
+        />
         <div className="modal-body">
           <h2>{event.title[language]}</h2>
           <div className="event-details">
@@ -625,9 +647,6 @@ const App = () => {
               <div className="hero-content">
                 <h2>{t('discoverTitle')}</h2>
                 <p>{t('discoverSubtitle')}</p>
-              </div>
-              <div className="hero-image">
-                <img src="https://images.unsplash.com/photo-1658329717628-4c051a4c6820?crop=entropy&cs=srgb&fm=jpg&ixid=M3w3NDk1Nzd8MHwxfHNlYXJjaHwxfHxWYWxlbmNpYSUyMGNpdHlzY2FwZXxlbnwwfHx8Ymx1ZXwxNzUyNDMwMDU0fDA&ixlib=rb-4.1.0&q=85" alt="Valencia cityscape" />
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- set `/images/background.png` as the app background
- add onError fallback to show `/images/event.png` when event images fail
- remove the Unsplash hero image from the home page

## Testing
- `yarn test --watchAll=false --passWithNoTests`
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68792627c9f4832395d85da51528f144