### PR TITLE
Improve background readability

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -27,6 +27,7 @@
   --transition-fast: all 0.2s ease;
   --transition-medium: all 0.3s ease;
   --transition-slow: all 0.5s ease;
+  --page-overlay: rgba(255, 255, 255, 0.6);
 }
 
 /* Dark mode variables */
@@ -41,6 +42,7 @@
   --bg-overlay: rgba(0, 0, 0, 0.8);
   
   --border-color: #4b5563;
+  --page-overlay: rgba(0, 0, 0, 0.6);
 }
 
 /* Base styles */
@@ -60,6 +62,7 @@ body {
 }
 
 .app {
+  position: relative;
   min-height: 100vh;
   background-color: var(--bg-primary);
   background-image: url('/images/background.png');
@@ -68,6 +71,15 @@ body {
   background-attachment: fixed;
   color: var(--text-primary);
   transition: var(--transition-medium);
+}
+
+.app::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: var(--page-overlay);
+  pointer-events: none;
+  z-index: -1;
 }
 
 /* Header styles */


### PR DESCRIPTION
## Summary
- add page overlay variable for bright and dark themes
- overlay entire app to make background images readable

## Testing
- `yarn test --watchAll=false --passWithNoTests`
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68793bdafed88323b137130eacdc29b3