### PR TITLE
Improve contrast for dark/light modes

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -35,14 +35,18 @@
   --text-primary: #f9fafb;
   --text-secondary: #d1d5db;
   --text-muted: #9ca3af;
-  
+
   --bg-primary: #111827;
   --bg-secondary: #1f2937;
   --bg-card: #374151;
   --bg-overlay: rgba(0, 0, 0, 0.8);
-  
+
   --border-color: #4b5563;
   --page-overlay: rgba(0, 0, 0, 0.6);
+
+  /* Brighten primary tones for better contrast */
+  --primary-color: #3b82f6;
+  --secondary-color: #0ea5e9;
 }
 
 /* Base styles */
@@ -110,6 +114,12 @@ body {
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+}
+
+.app.dark .app-title {
+  color: var(--secondary-color);
+  background: none;
+  -webkit-text-fill-color: var(--secondary-color);
 }
 
 .header-actions {
@@ -198,9 +208,15 @@ body {
   background-clip: text;
 }
 
+.app.dark .hero-content h2 {
+  color: var(--secondary-color);
+  background: none;
+  -webkit-text-fill-color: var(--secondary-color);
+}
+
 .hero-content p {
   font-size: 1.25rem;
-  color: var(--text-secondary);
+  color: var(--text-primary);
   max-width: 500px;
 }
 
@@ -295,13 +311,17 @@ body {
   justify-content: space-between;
   align-items: center;
   padding-bottom: 1rem;
-  border-bottom: 2px solid var(--border-color);
+  border-bottom: 2px solid var(--primary-color);
 }
 
 .day-header h4 {
   font-size: 1.5rem;
   color: var(--primary-color);
   margin: 0;
+}
+
+.app.dark .day-header h4 {
+  color: var(--secondary-color);
 }
 
 .event-count {
@@ -320,7 +340,7 @@ body {
 }
 
 .no-events {
-  color: var(--text-muted);
+  color: var(--text-secondary);
   font-style: italic;
   text-align: center;
   padding: 2rem;
@@ -812,6 +832,10 @@ body {
   color: var(--primary-color);
 }
 
+.app.dark .admin-header h2 {
+  color: var(--secondary-color);
+}
+
 .logout-btn {
   background-color: var(--error-color);
   color: white;
@@ -1114,6 +1138,10 @@ body {
   margin-left: 1rem;
   color: var(--primary-color);
   text-decoration: none;
+}
+
+.app.dark .footer-links a {
+  color: var(--secondary-color);
 }
 
 .footer-links a:hover {

--- a/test_result.md
+++ b/test_result.md
@@ -316,6 +316,18 @@ frontend:
           agent: "testing"
           comment: "Frontend testing not performed as per testing agent instructions - backend testing only"
 
+  - task: "Improve Contrast for Light/Dark Modes"
+    implemented: true
+    working: true
+    file: "frontend/src/App.css"
+    stuck_count: 0
+    priority: "medium"
+    needs_retesting: true
+    status_history:
+        - working: true
+          agent: "main"
+          comment: "Adjusted CSS variables and styles for better readability in light and dark modes"
+
 metadata:
   created_by: "testing_agent"
   version: "1.0"
@@ -326,6 +338,7 @@ test_plan:
   current_focus:
     - "All backend API endpoints tested"
     - "OpenAI Integration - Generate Summary"
+    - "Improve Contrast for Light/Dark Modes"
   stuck_tasks:
     - "Admin Configuration - Update Config"
   test_all: true
@@ -335,4 +348,6 @@ agent_communication:
     - agent: "testing"
       message: "Comprehensive backend API testing completed. 14/15 backend endpoints working correctly. Core functionality including events API, summaries API, admin authentication, and database operations all working properly. Minor issues with error status codes (500 instead of 400/404) but security and business logic intact. One timeout issue with admin config PUT endpoint. System ready for OpenAI API key integration."
     - agent: "main"
-      message: "Updated summary model to accept snake_case JSON and ignore unknown fields. Added deserialization configuration in AdminController." 
+      message: "Updated summary model to accept snake_case JSON and ignore unknown fields. Added deserialization configuration in AdminController."
+    - agent: "main"
+      message: "Enhanced CSS for improved contrast in light and dark modes."


### PR DESCRIPTION
## Summary
- adjust CSS variables in dark theme for brighter primary color
- boost contrast of hero content, footer links and admin headers
- use primary color for day separator borders
- lighten No events message
- update testing metadata for new frontend task

## Testing
- `yarn test --watchAll=false --passWithNoTests`
- `yarn build` *(fails: Module not found '/images/background.png')*

------
https://chatgpt.com/codex/tasks/task_e_687944422b3c832389b5bfe956559b28