### PR TITLE
Add price field support

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -463,6 +463,11 @@ body {
   margin-top: auto;
 }
 
+.event-card-deck .event-price {
+  color: var(--text-secondary);
+  font-weight: bold;
+}
+
 /* Deck navigation */
 .deck-navigation {
   display: flex;
@@ -594,6 +599,12 @@ body {
   color: var(--text-secondary);
   line-height: 1.6;
   margin-bottom: 1rem;
+}
+
+.event-price {
+  color: var(--text-secondary);
+  font-weight: bold;
+  margin-bottom: 0.5rem;
 }
 
 .event-source {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -43,6 +43,7 @@ const App = () => {
       location: 'Location',
       address: 'Address',
       district: 'District',
+      price: 'Price',
       viewOn: 'View on',
       adminPanel: 'Admin Panel',
       logout: 'Logout',
@@ -86,6 +87,7 @@ const App = () => {
       location: 'Ubicación',
       address: 'Dirección',
       district: 'Distrito',
+      price: 'Precio',
       viewOn: 'Ver en',
       adminPanel: 'Panel de Administración',
       logout: 'Cerrar Sesión',
@@ -358,6 +360,11 @@ const App = () => {
           {event.location.name[language]}, {event.location.district}
         </p>
         <p className="event-description">{event.description[language]}</p>
+        {event.price && (
+          <div className="event-price">
+            <span>{t('price')}: {event.price}</span>
+          </div>
+        )}
         <div className="event-source">
           <span>{t('source')}: {event.source.provider}</span>
         </div>
@@ -417,6 +424,11 @@ const App = () => {
                   {event.location.name[language]}, {event.location.district}
                 </p>
                 <p className="event-description">{event.description[language]}</p>
+                {event.price && (
+                  <div className="event-price">
+                    <span>{t('price')}: {event.price}</span>
+                  </div>
+                )}
                 <div className="event-source">
                   <span>{t('source')}: {event.source.provider}</span>
                 </div>
@@ -479,6 +491,11 @@ const App = () => {
             <div className="detail-item">
               <strong>{t('district')}:</strong> {event.location.district}
             </div>
+            {event.price && (
+              <div className="detail-item">
+                <strong>{t('price')}:</strong> {event.price}
+              </div>
+            )}
           </div>
           <p className="event-description">{event.description[language]}</p>
           <div className="event-source">

--- a/src/main/java/com/example/events/model/Event.java
+++ b/src/main/java/com/example/events/model/Event.java
@@ -30,6 +30,8 @@ public class Event {
     private LocalizedText description;
     private String imageUrl;
 
+    private String price;
+
     @Embedded
     private Source source;
 }

--- a/src/main/resources/prompts.json
+++ b/src/main/resources/prompts.json
@@ -1,14 +1,20 @@
 {
   "valencia_events": {
     "role": "You are a bilingual (English/Spanish) Valencia ( in Spain )  event researcher with official tourism sources. Your task is to deliver 100% verified events with machine-readable accuracy",
-    "instruction": "Generate ONLY a JSON array of authentic events in Valencia between {{start_date}} and {{end_date}}, with strict adherence to these rules:\n\n1. **Data Integrity**:\n   - Verify ALL URLs (imageUrl, source.url), please bring real image url from the source, if not a placeholder\n   - If no event image exists, use this fallback hierarchy:\n     1) Venue logo from official website\n     2) Generic event type image (e.g., 'music_icon.png')\n     3) Omit field if no substitute exists\n   - Ensure dates are within range (reject otherwise).\n\n2. **Bilingual Output**:\n   - Provide descriptions in BOTH English and Spanish (escape special chars):\n     \"description\": {\n       \"en\": \"Experience...\",\n       \"es\": \"Vive...\"\n     }\n\n3. **Output Format**:\n   - Exactly match this structure (2-space indents):\n     {\n       \"title\": {\"en\": \"Running Festival\", \"es\": \"Festival de Running\"},\n       \"date\": \"2025-06-22\",\n       \"location\": {\n         \"name\": {\"en\": \"City of Arts\", \"es\": \"Ciudad de las Artes\"},\n         \"address\": \"Av. Profesor López Piñero, 7\",\n         \"district\": \"Quatre Carreres\"\n       },\n       \"description\": {\n         \"en\": \"Experience running...\",\n         \"es\": \"Vive el running...\"\n       },\n       \"imageUrl\": \"https://example.com/image.jpg\", // Must be HTTPS\n       \"source\": {\n         \"url\": \"https://valencia.es/event\",\n         \"provider\": \"Valencia City Council\"\n       } }\n\n4. **Validation Protocol**:\n   - Cross-check with:\n     1) valencia.es/agenda\n     2) visitvalencia.com\n     3) Eventbrite (Valencia-filtered)\n     4) https://en.fiestas.net/valencia/\n   - Reject if:\n     - No physical address\n     - No organizer contact email/phone\n     - Date outside requested range. \n  NOTE: make sure to bring at least 3 events per day",
+    "instruction": "Generate ONLY a JSON array of authentic events in Valencia between {{start_date}} and {{end_date}}, with strict adherence to these rules:\n\n1. **Data Integrity**:\n   - Verify ALL URLs (imageUrl, source.url), please bring real image url from the source, if not a placeholder\n   - If no event image exists, use this fallback hierarchy:\n     1) Venue logo from official website\n     2) Generic event type image (e.g., 'music_icon.png')\n     3) Omit field if no substitute exists\n   - Ensure dates are within range (reject otherwise).\n\n2. **Bilingual Output**:\n   - Provide descriptions in BOTH English and Spanish (escape special chars):\n     \"description\": {\n       \"en\": \"Experience...\",\n       \"es\": \"Vive...\"\n     }\n\n3. **Output Format**:\n   - Exactly match this structure (2-space indents):\n     {\n       \"title\": {\"en\": \"Running Festival\", \"es\": \"Festival de Running\"},\n       \"date\": \"2025-06-22\",\n       \"location\": {\n         \"name\": {\"en\": \"City of Arts\", \"es\": \"Ciudad de las Artes\"},\n         \"address\": \"Av. Profesor L\u00f3pez Pi\u00f1ero, 7\",\n         \"district\": \"Quatre Carreres\"\n       },\n       \"description\": {\n         \"en\": \"Experience running...\",\n         \"es\": \"Vive el running...\"\n       },\n       \"imageUrl\": \"https://example.com/image.jpg\", // Must be HTTPS\n       \"source\": {\n         \"url\": \"https://valencia.es/event\",\n         \"provider\": \"Valencia City Council\"\n       },\n       \"price\": \"\u20ac35\"\n     }\n\n4. **Validation Protocol**:\n   - Cross-check with:\n     1) valencia.es/agenda\n     2) visitvalencia.com\n     3) Eventbrite (Valencia-filtered)\n     4) https://en.fiestas.net/valencia/\n   - Reject if:\n     - No physical address\n     - No organizer contact email/phone\n     - Date outside requested range. \n  NOTE: make sure to bring at least 3 events per day\n",
     "examples": [
       {
-        "title": {"en": "Fallas Festival", "es": "Fallas"},
+        "title": {
+          "en": "Fallas Festival",
+          "es": "Fallas"
+        },
         "date": "2025-03-15",
         "location": {
-          "name": {"en": "Plaza del Ayuntamiento", "es": "Plaça de l'Ajuntament"},
-          "address": "Plaça de l'Ajuntament, 1",
+          "name": {
+            "en": "Plaza del Ayuntamiento",
+            "es": "Pla\u00e7a de l'Ajuntament"
+          },
+          "address": "Pla\u00e7a de l'Ajuntament, 1",
           "district": "Ciutat Vella"
         },
         "description": {
@@ -25,7 +31,7 @@
   },
   "valencia_events_summary": {
     "role": "Valencia's official bilingual cultural concierge. ( Valencia, Spain )",
-    "instruction": "Create a 80-100 word summary in JSON format with:\n\n1. **Content Rules**:\n   - Bilingual output (English/Spanish)\n   - Include:\n     - 3-4 event highlights\n     - 1 Valencian idiom (e.g., \"més val tard que mai\")\n     - 1 neighborhood mention\n     - Event types array ([\"music\", \"food\"])\n\n2. **Format**:\n   {\n     \"summary\": {\n       \"en\": \"Valencia comes alive...\",\n       \"es\": \"Valencia cobra vida...\"\n     },\n     \"start_date\": \"{{start_date}}\",\n     \"end_date\": \"{{end_date}}\",\n     \"event_types\": [\"culture\", \"sports\"],\n     \"idiom\": {\n       \"phrase\": \"més val tard que mai\",\n       \"meaning\": \"better late than never\"\n     }\n   }\n\n3. **Validation**:\n   - Use ONLY events from `valencia_events` output\n   - Idioms must be sourced from:\n     - DNV (Diccionari Normatiu Valencià)\n     - AVL (Acadèmia Valenciana de la Llengua)",
+    "instruction": "Create a 80-100 word summary in JSON format with:\n\n1. **Content Rules**:\n   - Bilingual output (English/Spanish)\n   - Include:\n     - 3-4 event highlights\n     - 1 Valencian idiom (e.g., \"m\u00e9s val tard que mai\")\n     - 1 neighborhood mention\n     - Event types array ([\"music\", \"food\"])\n\n2. **Format**:\n   {\n     \"summary\": {\n       \"en\": \"Valencia comes alive...\",\n       \"es\": \"Valencia cobra vida...\"\n     },\n     \"start_date\": \"{{start_date}}\",\n     \"end_date\": \"{{end_date}}\",\n     \"event_types\": [\"culture\", \"sports\"],\n     \"idiom\": {\n       \"phrase\": \"m\u00e9s val tard que mai\",\n       \"meaning\": \"better late than never\"\n     }\n   }\n\n3. **Validation**:\n   - Use ONLY events from `valencia_events` output\n   - Idioms must be sourced from:\n     - DNV (Diccionari Normatiu Valenci\u00e0)\n     - AVL (Acad\u00e8mia Valenciana de la Llengua)",
     "examples": [
       {
         "summary": {
@@ -34,9 +40,12 @@
         },
         "start_date": "2025-03-10",
         "end_date": "2025-03-16",
-        "event_types": ["culture", "tradition"],
+        "event_types": [
+          "culture",
+          "tradition"
+        ],
         "idiom": {
-          "phrase": "més val tard que mai",
+          "phrase": "m\u00e9s val tard que mai",
           "meaning": "better late than never"
         }
       }

--- a/test_result.md
+++ b/test_result.md
@@ -303,6 +303,18 @@ backend:
           agent: "testing"
           comment: "Minor: Invalid event IDs return 500 instead of 404, but request is properly handled without system failure"
 
+  - task: "Price Field for Events"
+    implemented: true
+    working: true
+    file: "src/main/java/com/example/events/model/Event.java"
+    stuck_count: 0
+    priority: "medium"
+    needs_retesting: true
+    status_history:
+        - working: true
+          agent: "main"
+          comment: "Added price field to Event model and prompt instructions"
+
 frontend:
   - task: "Frontend Testing"
     implemented: false
@@ -351,6 +363,18 @@ frontend:
         - working: true
           agent: "main"
           comment: "Redesigned calendar with glass-morphism styling, gradients and hover interactions"
+
+  - task: "Display Event Price"
+    implemented: true
+    working: true
+    file: "frontend/src/App.js"
+    stuck_count: 0
+    priority: "medium"
+    needs_retesting: true
+    status_history:
+        - working: true
+          agent: "main"
+          comment: "Added price field display in event cards and modal"
 
 metadata:
   created_by: "testing_agent"


### PR DESCRIPTION
## Summary
- add `price` to Event entity and prompts
- display event price in React UI
- include translation strings and CSS styles for price
- track new tasks in `test_result.md`

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687a260c96f88323904b3c0477f4061f