### PR TITLE
Fix calendar cell clipping

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -652,7 +652,7 @@ body {
 
 .calendar-weekdays {
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
+  grid-template-columns: repeat(7, minmax(0, 1fr));
   background: rgba(255, 255, 255, 0.3);
   backdrop-filter: blur(6px);
   width: 100%;
@@ -681,7 +681,7 @@ body {
 
 .calendar-grid {
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
+  grid-template-columns: repeat(7, minmax(0, 1fr));
   gap: 1rem;
   padding: 1rem;
   width: 100%;

--- a/test_result.md
+++ b/test_result.md
@@ -369,6 +369,9 @@ frontend:
         - working: true
           agent: "main"
           comment: "Fixed calendar grid overflow so right edge no longer gets cut off"
+        - working: true
+          agent: "main"
+          comment: "Adjusted grid to use minmax columns so events don't clip the calendar edge"
 
   - task: "Contact Form Layout"
     implemented: true
@@ -429,3 +432,5 @@ agent_communication:
       message: "Widened contact form and enlarged calendar layout; events now display below the calendar"
     - agent: "main"
       message: "Fixed calendar overflow on narrow screens so right edge is fully visible"
+    - agent: "main"
+      message: "Updated calendar grid columns with minmax to prevent clipping when events are shown"


### PR DESCRIPTION
## Summary
- prevent calendar cells from clipping by using `minmax(0, 1fr)`
- document fix in test results

## Testing
- `yarn test --watchAll=false --passWithNoTests`
- `mvn -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687a33a78ee883238a0486a85ae60a46