### PR TITLE
Fix event detail modal overlay

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, Fragment } from 'react';
-import { Dialog, Menu, Transition } from '@headlessui/react';
+import { Dialog, Menu, Transition, DialogBackdrop } from '@headlessui/react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMapMarkerAlt, faTimes, faSpinner, faBars } from '@fortawesome/free-solid-svg-icons';
 import { faInstagram, faWhatsapp } from '@fortawesome/free-brands-svg-icons';
@@ -474,7 +474,7 @@ const App = () => {
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <Dialog.Overlay className="fixed inset-0 bg-black bg-opacity-40" />
+            <DialogBackdrop className="fixed inset-0 bg-black bg-opacity-40" />
           </Transition.Child>
 
           <span className="inline-block h-screen align-middle" aria-hidden="true">

--- a/test_result.md
+++ b/test_result.md
@@ -468,6 +468,9 @@ frontend:
         - working: true
           agent: "main"
           comment: "Replaced modal and navigation with Headless UI Dialog and Menu"
+        - working: true
+          agent: "main"
+          comment: "Fixed Dialog overlay by using DialogBackdrop for event details"
 
   - task: "FontAwesome Icons"
     implemented: true


### PR DESCRIPTION
## Summary
- add DialogBackdrop import from headlessui
- use DialogBackdrop instead of Dialog.Overlay
- document fix in test status

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6884f2de5f648323a2b01c41a656749c