### PR TITLE
Fix modal close position and overlay click

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -474,7 +474,10 @@ const App = () => {
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <DialogBackdrop className="fixed inset-0 bg-black bg-opacity-40" />
+            <DialogBackdrop
+              className="fixed inset-0 bg-black bg-opacity-40"
+              onClick={onClose}
+            />
           </Transition.Child>
 
           <span className="inline-block h-screen align-middle" aria-hidden="true">
@@ -489,8 +492,8 @@ const App = () => {
             leaveFrom="opacity-100 scale-100"
             leaveTo="opacity-0 scale-95"
           >
-            <div className="inline-block w-full max-w-md transform overflow-hidden rounded-lg bg-white dark:bg-gray-700 p-6 text-left align-middle shadow-xl transition-all">
-              <button className="absolute right-4 top-4 text-gray-500" onClick={onClose}>
+            <div className="relative inline-block w-full max-w-md transform overflow-hidden rounded-lg bg-white dark:bg-gray-700 p-6 text-left align-middle shadow-xl transition-all">
+              <button className="absolute -right-3 -top-3 text-gray-500 bg-white rounded-full p-2 shadow" onClick={onClose}>
                 <FontAwesomeIcon icon={faTimes} />
               </button>
               <img

--- a/test_result.md
+++ b/test_result.md
@@ -471,6 +471,9 @@ frontend:
         - working: true
           agent: "main"
           comment: "Fixed Dialog overlay by using DialogBackdrop for event details"
+        - working: true
+          agent: "main"
+          comment: "Moved modal close button outside image and enabled closing on background click"
 
   - task: "FontAwesome Icons"
     implemented: true
@@ -529,4 +532,6 @@ agent_communication:
       message: "Adjusted contact panel width to fully span available space"
     - agent: "main"
       message: "Integrated Tailwind design with Headless UI modals and FontAwesome icons"
+    - agent: "main"
+      message: "Moved modal close button outside image and enabled closing dialog when clicking outside"
 


### PR DESCRIPTION
## Summary
- move modal close button outside the event image
- allow closing the dialog by clicking the backdrop

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6884f61d278c83238e5870f29d08bf45